### PR TITLE
Compilation error  and zero window fix

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1,6 +1,6 @@
 
 EXEC=rastertotpcl
-CFLAGS=-lcupsimage
+LDLIBS=-lcupsimage -lm -lcups
 PPDPATH=/usr/share/ppd
 EXECPATH=/usr/lib/cups/filter
 

--- a/src/rastertotpcl.c
+++ b/src/rastertotpcl.c
@@ -289,7 +289,7 @@ StartPage(ppd_file_t         *ppd,	/* I - PPD file */
   width = (int) (header->cupsPageSize[0] * 254/72);
 
   /* Send label size, assume gap is same all the way round */
-  printf("{D%04d,%04d,%04d|}\n",labelpitch, width, length, width + labelgap); 
+  printf("{D%04d,%04d,%04d|}\n",labelpitch, width, length); 
 
   /*
    * Place the right command in the parameter AY temperature fine adjust
@@ -596,6 +596,8 @@ EndPage(ppd_file_t *ppd,		/* I - PPD file */
     /* Send eject command if cut active */
     if (CutActive > 0)
       printf("{IB|}\n");
+    // To avoid Zerowindow Error at the end of the stream
+    printf("%1024s","");
 
   } // Not Cancelled
 
@@ -780,7 +782,7 @@ void TOPIXCompressOutputBuffer(ppd_file_t          *ppd,	   /* PPD file */
   /*
    * Output the complete graphics line to STDOUT
    */
-  printf("{SG;0000,%04dD,%04d,%04d,%d,", CompLastLine, header->cupsBytesPerLine * 8, 300, Gmode);
+  printf("{SG;0000,%04d,%04d,%04d,%d,", CompLastLine, header->cupsBytesPerLine * 8, 300, Gmode);
   fwrite(&belen, 2, 1, stdout);       // Length of data
   fwrite(CompBuffer, 1, len, stdout); // Data
   printf("|}\n");


### PR DESCRIPTION
There is a compilation error. Also the Makefile need a fix to work properly.
In B-E4VT printer sometimes receives an error at the end, loosing FN package. Adding dummy data at the end this problem is solved.