### PR TITLE
Update rastertotpcl.c

### DIFF
--- a/src/rastertotpcl.c
+++ b/src/rastertotpcl.c
@@ -44,6 +44,7 @@
  */
 
 #include <cups/cups.h>
+#include <cups/ppd.h>
 #include <cups/raster.h>
 #include <stdlib.h>
 #include <unistd.h>


### PR DESCRIPTION
added "#include <cups/ppd.h>" in rastertotpcl.c to fix some compilation errors in Arch Linux ARM. Tested with Toshiba TEC B-EV4T-GS14