### PR TITLE
Deprecated ppd API is moved to <cups/ppd.h>. Minor changes to make dr…

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1,6 +1,6 @@
 
 EXEC=rastertotpcl
-CFLAGS=-lcupsimage
+CFLAGS=-lcupsimage -lcups
 PPDPATH=/usr/share/ppd
 EXECPATH=/usr/lib/cups/filter
 

--- a/src/rastertotpcl.c
+++ b/src/rastertotpcl.c
@@ -44,12 +44,14 @@
  */
 
 #include <cups/cups.h>
+#include <cups/ppd.h>
 #include <cups/raster.h>
 #include <stdlib.h>
 #include <unistd.h>
 #include <fcntl.h>
 #include <signal.h>
 #include <math.h>
+#include <stdio.h>
 
 
 /*


### PR DESCRIPTION
…ivers compile with cups 2.2.*

This should fix issue 3.